### PR TITLE
Release 0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onfido-sdk-core",
-  "version": "1.0.0",
+  "version": "0.4",
   "description": "JavaScript SDK core layer for Onfido identity verification",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onfido-sdk-core",
-  "version": "0.4",
+  "version": "0.4.0",
   "description": "JavaScript SDK core layer for Onfido identity verification",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onfido-sdk-core",
-  "version": "0.3.2",
+  "version": "1.0.0",
   "description": "JavaScript SDK core layer for Onfido identity verification",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Breaking changes cannot be submitted to patch level while on 0.x
Specially because onfido-sdk-ui 0.4 is using a caret for dependency ("onfido-sdk-core": "^0.3.0"). This means it will update to any release which is 0.3.x
versions 0.3.2 and 0.3.1 have been unpublished.
