### PR TITLE
Improvement: Made all selectors capture type agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,21 @@ Breaking changes result in a different major. UI changes that might break custom
 ### Changed
 - The action `validCapture` has been changed to `validateCapture`.
 - The payload of the action `createCapture` has changed from `{...data: object}` to `{...capture: object}`.
+- All selectors have now been changed from having identical pairs of selectors for both `document` and `face` to be capture type agnostic selectors, meaning they are now mapped into the captures hash which includes all capture types as keys.
+- `faceSelector|documentSelector:[Object]` changed to `validCaptures:{string:[Object]}`
+- `documentCaptured|faceCaptured:boolean` changed to `isThereAValidCapture:{string:boolean}`.
+- `faceValidAndConfirmed|documentValidAndConfirmed:boolean` changed to `isThereAValidAndConfirmedCapture:{string:boolean}`
+
 
 ### Added
 - The action `validateCapture` now also changes the value in the capture of the property `processed` to `true` whenever the action is called.
 - The action `createCapture` can now accept a new optional parameter called `maxCaptures: int`, which determines how many captures are stored. The default of `maxCaptures` is `3`.
 - The payload of the action `validateCapture` can have an extra parameter called `valid: boolean` which is optional and defaults to `true`, this can be used to invalidate the capture.
-- There is a new selector called `unprocessedDocuments` that provides a list of documents which have not been processed (meaning they have not been validated/invalidated)
-
-
+- There is a new selector called `unprocessedCaptures:{string:[Capture]}` which returns a list of captures which have not yet been been validated/invalidated for each capture type.
+- There is a new selector `hasUnprocessedCaptures:{string:boolean}` which returns a boolean on whether there are unprocessed Captures for each capture type.
+- There is a new selector `areAllCapturesInvalid:{string:boolean}` which returns a boolean on whether all of its captures are invalid for each capture type.
+- Events are now sent for any capture type.
+- The selector `allCaptured` is now capture type agnostic, but still backwards compatible.
 
 
 ## [0.5.0]

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'eventemitter2'
 import store from '../store/store'
 import * as selectors from '../store/selectors'
+import { each } from 'lodash'
 
 const events = new EventEmitter()
 store.subscribe(handleEvent)
@@ -13,12 +14,9 @@ function handleEvent() {
   if (authenticated(state)) {
     events.emit('ready')
   }
-  if (selectors.documentCaptured(state)) {
-    events.emit('documentCapture', data)
-  }
-  if (selectors.faceCaptured(state)) {
-    events.emit('faceCapture', data)
-  }
+  each(selectors.isThereAValidCapture(state), (isValid, captureType) => {
+    if (isValid) events.emit(captureType+'Capture', data)
+  })
   if (selectors.allCaptured(state)) {
     events.emit('complete', data)
   }

--- a/src/store/selectors/index.js
+++ b/src/store/selectors/index.js
@@ -1,53 +1,53 @@
 import { createSelector } from 'reselect'
+import { mapValues, curry, every } from 'lodash'
 
-const documentCaptures = state => state.captures.document
-const faceCaptures = state => state.captures.face
+const captures = state => state.captures
 
-export const documentCaptured = createSelector(
-  documentCaptures,
-  documents => documents.some(i => i.valid)
+const mapValuesFlippedAndCurried = curry((mapFunc, objectToMap) => mapValues(objectToMap, mapFunc))
+
+export const isThereAValidCapture = createSelector(
+  captures,
+  mapValuesFlippedAndCurried(capturesOfAType => capturesOfAType.some(i => i.valid))
 )
 
-export const documentValidAndConfirmed= createSelector(
-  documentCaptures,
-  documents => documents.some(i => i.valid && i.confirmed)
+export const isThereAValidAndConfirmedCapture = createSelector(
+  captures,
+  mapValuesFlippedAndCurried(capturesOfAType => capturesOfAType.some(i => i.valid && i.confirmed))
 )
 
-export const documentSelector = createSelector(
-  documentCaptures,
-  documents => documents.filter(i => i.valid)
-)
-
-export const faceCaptured = createSelector(
-  faceCaptures,
-  faces => faces.some(i => i.valid)
-)
-
-export const faceValidAndConfirmed= createSelector(
-  faceCaptures,
-  faces => faces.some(i => i.valid && i.confirmed)
-)
-
-export const faceSelector = createSelector(
-  faceCaptures,
-  faces => faces.filter(i => i.valid)
+export const validCaptures = createSelector(
+  captures,
+  mapValuesFlippedAndCurried(capturesOfAType => capturesOfAType.filter(i => i.valid))
 )
 
 export const allCaptured = createSelector(
-  documentValidAndConfirmed,
-  faceValidAndConfirmed,
-  (a, b) => [a, b].every(i => i)
+  isThereAValidAndConfirmedCapture,
+  obj => every(obj, i => i)
 )
 
 export const captureSelector = createSelector(
-  documentSelector,
-  faceSelector,
-  (documentCapture, faceCapture) => ({
-    documentCapture: documentCapture[0],
-    faceCapture: faceCapture[0]
+  validCaptures,
+  ({ document:validDocumentCaptures, face:validFaceCaptures }) => ({
+    documentCapture: validDocumentCaptures[0],
+    faceCapture: validFaceCaptures[0]
   })
 )
 
-export const unprocessedDocuments = createSelector(documentCaptures, (documentCapturesValue) => (
-  documentCapturesValue.filter(documentValue => !documentValue.processed)
+export const unprocessedCaptures = createSelector(
+  captures,
+  mapValuesFlippedAndCurried(capturesOfAType =>
+    capturesOfAType.filter(i => !i.processed))
+)
+
+export const hasUnprocessedCaptures= createSelector(
+  captures,
+  mapValuesFlippedAndCurried( capturesOfAType =>
+    capturesOfAType.some(i => !i.processed)
 ))
+
+export const areAllCapturesInvalid = createSelector(
+  captures,
+  mapValuesFlippedAndCurried(capturesOfAType =>
+    capturesOfAType.length > 0 && capturesOfAType.every(i => i.processed && !i.valid)
+  )
+)

--- a/src/store/selectors/index.js
+++ b/src/store/selectors/index.js
@@ -4,21 +4,17 @@ import { mapValues, curry, every } from 'lodash'
 const captures = state => state.captures
 
 const mapValuesFlippedAndCurried = curry((mapFunc, objectToMap) => mapValues(objectToMap, mapFunc))
+const createSelectorBoundToCapturesAndMapValues = (mapFunc) =>
+  createSelector(captures, mapValuesFlippedAndCurried(mapFunc))
 
-export const isThereAValidCapture = createSelector(
-  captures,
-  mapValuesFlippedAndCurried(capturesOfAType => capturesOfAType.some(i => i.valid))
-)
+export const isThereAValidCapture = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
+  capturesOfAType.some(i => i.valid))
 
-export const isThereAValidAndConfirmedCapture = createSelector(
-  captures,
-  mapValuesFlippedAndCurried(capturesOfAType => capturesOfAType.some(i => i.valid && i.confirmed))
-)
+export const isThereAValidAndConfirmedCapture = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
+  capturesOfAType.some(i => i.valid && i.confirmed))
 
-export const validCaptures = createSelector(
-  captures,
-  mapValuesFlippedAndCurried(capturesOfAType => capturesOfAType.filter(i => i.valid))
-)
+export const validCaptures = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
+  capturesOfAType.filter(i => i.valid))
 
 export const allCaptured = createSelector(
   isThereAValidAndConfirmedCapture,
@@ -33,21 +29,11 @@ export const captureSelector = createSelector(
   })
 )
 
-export const unprocessedCaptures = createSelector(
-  captures,
-  mapValuesFlippedAndCurried(capturesOfAType =>
+export const unprocessedCaptures = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
     capturesOfAType.filter(i => !i.processed))
-)
 
-export const hasUnprocessedCaptures= createSelector(
-  captures,
-  mapValuesFlippedAndCurried( capturesOfAType =>
-    capturesOfAType.some(i => !i.processed)
-))
+export const hasUnprocessedCaptures= createSelectorBoundToCapturesAndMapValues( capturesOfAType =>
+    capturesOfAType.some(i => !i.processed))
 
-export const areAllCapturesInvalid = createSelector(
-  captures,
-  mapValuesFlippedAndCurried(capturesOfAType =>
-    capturesOfAType.length > 0 && capturesOfAType.every(i => i.processed && !i.valid)
-  )
-)
+export const areAllCapturesInvalid = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
+    capturesOfAType.length > 0 && capturesOfAType.every(i => i.processed && !i.valid))

--- a/src/store/selectors/index.js
+++ b/src/store/selectors/index.js
@@ -1,20 +1,28 @@
 import { createSelector } from 'reselect'
-import { mapValues, curry, every } from 'lodash'
+import { mapValues, mapKeys, every } from 'lodash'
 
 const captures = state => state.captures
 
-const mapValuesFlippedAndCurried = curry((mapFunc, objectToMap) => mapValues(objectToMap, mapFunc))
-const createSelectorBoundToCapturesAndMapValues = (mapFunc) =>
-  createSelector(captures, mapValuesFlippedAndCurried(mapFunc))
+const createSelectorWhichMapsToCaptures = (mapFunc) =>
+  createSelector(captures, capturesValue => mapValues(capturesValue, mapFunc))
 
-export const isThereAValidCapture = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
+export const isThereAValidCapture = createSelectorWhichMapsToCaptures(capturesOfAType =>
   capturesOfAType.some(i => i.valid))
 
-export const isThereAValidAndConfirmedCapture = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
+export const isThereAValidAndConfirmedCapture = createSelectorWhichMapsToCaptures(capturesOfAType =>
   capturesOfAType.some(i => i.valid && i.confirmed))
 
-export const validCaptures = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
+export const validCaptures = createSelectorWhichMapsToCaptures(capturesOfAType =>
   capturesOfAType.filter(i => i.valid))
+
+export const unprocessedCaptures = createSelectorWhichMapsToCaptures(capturesOfAType =>
+    capturesOfAType.filter(i => !i.processed))
+
+export const hasUnprocessedCaptures= createSelectorWhichMapsToCaptures( capturesOfAType =>
+    capturesOfAType.some(i => !i.processed))
+
+export const areAllCapturesInvalid = createSelectorWhichMapsToCaptures(capturesOfAType =>
+    capturesOfAType.length > 0 && capturesOfAType.every(i => i.processed && !i.valid))
 
 export const allCaptured = createSelector(
   isThereAValidAndConfirmedCapture,
@@ -23,17 +31,7 @@ export const allCaptured = createSelector(
 
 export const captureSelector = createSelector(
   validCaptures,
-  ({ document:validDocumentCaptures, face:validFaceCaptures }) => ({
-    documentCapture: validDocumentCaptures[0],
-    faceCapture: validFaceCaptures[0]
-  })
+  validCapturesValue => mapKeys(
+    mapValues(validCapturesValue, ([firstCapture]) => firstCapture),
+    (v, key) => key + 'Capture')
 )
-
-export const unprocessedCaptures = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
-    capturesOfAType.filter(i => !i.processed))
-
-export const hasUnprocessedCaptures= createSelectorBoundToCapturesAndMapValues( capturesOfAType =>
-    capturesOfAType.some(i => !i.processed))
-
-export const areAllCapturesInvalid = createSelectorBoundToCapturesAndMapValues(capturesOfAType =>
-    capturesOfAType.length > 0 && capturesOfAType.every(i => i.processed && !i.valid))


### PR DESCRIPTION
1. Made all selectors capture type agnostic
2. Added two new selectors: `hasUnprocessedCaptures` and `areAllCapturesInvalid`

See CHANGELOG for a more complete summary.
